### PR TITLE
Fix Vagrant provisioning via the shells scripts don't work because of legacy apt repository

### DIFF
--- a/app-a/ch03/cluster-upgrade-version/Vagrantfile
+++ b/app-a/ch03/cluster-upgrade-version/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.25.6-00"}
+    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.25.6-1.1"}
     node.vm.provision "shell", path: "../../vagrant-scripts/control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
   end
 
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.25.6-00"}
+      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.25.6-1.1"}
       node.vm.provision "shell", path: "../../vagrant-scripts/worker.sh", args: "#{i}"
     end
   end

--- a/app-a/ch04/apparmor/Vagrantfile
+++ b/app-a/ch04/apparmor/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
     node.vm.provision "shell", path: "../../vagrant-scripts/control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
     node.vm.provision "shell", path: "pod-setup.sh"
   end
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
       node.vm.provision "shell", path: "../../vagrant-scripts/worker.sh", args: "#{i}"
     end
   end

--- a/app-a/ch04/close-ports/Vagrantfile
+++ b/app-a/ch04/close-ports/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
     node.vm.provision "shell", path: "../../vagrant-scripts/control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
   end
 
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
       node.vm.provision "shell", path: "../../vagrant-scripts/worker.sh", args: "#{i}"
       node.vm.provision "shell", path: "service-setup.sh"
     end

--- a/app-a/ch04/seccomp/Vagrantfile
+++ b/app-a/ch04/seccomp/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
     node.vm.provision "shell", path: "../../vagrant-scripts/control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
     node.vm.provision "shell", path: "pod-setup.sh"
   end
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
       node.vm.provision "shell", path: "../../vagrant-scripts/worker.sh", args: "#{i}"
     end
   end

--- a/app-a/ch05/gvisor/Vagrantfile
+++ b/app-a/ch05/gvisor/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
     node.vm.provision "shell", path: "../../vagrant-scripts/control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
   end
 
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
       node.vm.provision "shell", path: "../../vagrant-scripts/worker.sh", args: "#{i}"
       node.vm.provision "shell", path: "runsc.sh", args: "#{i}"
     end

--- a/app-a/ch07/audit-log/Vagrantfile
+++ b/app-a/ch07/audit-log/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
     node.vm.provision "shell", path: "../../vagrant-scripts/control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
     node.vm.provision "shell", path: "audit-policy-setup.sh"
   end
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
       node.vm.provision "shell", path: "../../vagrant-scripts/worker.sh", args: "#{i}"
     end
   end

--- a/app-a/ch07/falco/Vagrantfile
+++ b/app-a/ch07/falco/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
       vb.cpus = 2
     end
-    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+    node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
     node.vm.provision "shell", path: "../../vagrant-scripts/control-plane.sh", args: "#{POD_CIDR} #{API_ADV_ADDRESS}"
     node.vm.provision "shell", path: "pod-setup.sh"
   end
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
         vb.memory = 1024
         vb.cpus = 2
       end
-      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-00"}
+      node.vm.provision "shell", path: "../../vagrant-scripts/common.sh", env: {"K8S_VERSION" => "1.26.1-1.1"}
       node.vm.provision "shell", path: "../../vagrant-scripts/worker.sh", args: "#{i}"
       node.vm.provision "shell", path: "falco-install.sh"
     end

--- a/app-a/vagrant-scripts/common.sh
+++ b/app-a/vagrant-scripts/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -z ${K8S_VERSION+x} ]; then
-  K8S_VERSION=1.26.1-00
+  K8S_VERSION=1.26.1-1.1
 fi
 
 # Install containerd container runtime
@@ -30,8 +30,8 @@ sudo systemctl restart containerd
 
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo curl -fsSL "https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION:0:4}/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION:0:4}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # Install Kubernetes binaries
 sudo apt-get update

--- a/app-a/vagrant-scripts/control-plane.sh
+++ b/app-a/vagrant-scripts/control-plane.sh
@@ -5,6 +5,10 @@ API_ADV_ADDRESS=$2
 
 kubeadm init --pod-network-cidr $POD_CIDR --apiserver-advertise-address $API_ADV_ADDRESS | tee /vagrant/kubeadm-init.out
 
+# deb packages for kubelet on pkgs.k8s.io seem to include a systemd service definition for redhat machines #3276
+# apply same sed fix as in https://github.com/kubernetes/release/pull/3279
+sed -i 's;/etc/sysconfig/kubelet;/etc/default/kubelet;g' /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
 echo "KUBELET_EXTRA_ARGS=--node-ip=$API_ADV_ADDRESS --cgroup-driver=systemd" > /etc/default/kubelet
 systemctl restart kubelet
 

--- a/app-a/vagrant-scripts/worker.sh
+++ b/app-a/vagrant-scripts/worker.sh
@@ -5,6 +5,10 @@ NODE_HOST_IP="192.168.56.$((20+$NODE))"
 
 $(cat /vagrant/kubeadm-init.out | grep -A 2 "kubeadm join" | sed -e 's/^[ \t]*//' | tr '\n' ' ' | sed -e 's/ \\ / /g')
 
+# deb packages for kubelet on pkgs.k8s.io seem to include a systemd service definition for redhat machines #3276
+# apply same sed fix as in https://github.com/kubernetes/release/pull/3279
+sed -i 's;/etc/sysconfig/kubelet;/etc/default/kubelet;g' /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
 echo "KUBELET_EXTRA_ARGS=--node-ip=$NODE_HOST_IP --cgroup-driver=systemd" > /etc/default/kubelet
 systemctl restart kubelet
 


### PR DESCRIPTION
Thanks for providing the sample environments!

The vagrant provisioning via the shells scripts didn't work anymore because the [legacy repository](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/) was used.

The same patch versions as before aren't available on the new official project-owned repositories. Because of this, I upgraded to the next available patch level above the ones used before. There is a dedicated package repository for each Kubernetes minor version. That's why I extracted the first four characters as a quick fix.

After switching to the new apt repository, I ran into https://github.com/kubernetes/release/issues/3276. I copied the sed fix from https://github.com/kubernetes/release/pull/3279

I hope you have a great start to the new year! Thanks for your books!!